### PR TITLE
Draft attempt to fix inconsistency "concurrent removal/additions" by automatic UpdateMessages

### DIFF
--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -12,6 +12,7 @@ def lsformat(members):
     l = map(lambda x: x if isinstance(x, str) else x.id, members)
     return ",".join(sorted(l, key=lambda x: int(x[1:])))
 
+
 def lcformat(lastchanged):
     l = []
     for peer_id in sorted(lastchanged):
@@ -152,7 +153,7 @@ class IncomingMessage:
         name = self.typ
         if self.member:
             name += f"({self.member})"
-        return (f"{name} from={self.sender_id} to={rec} lastchanged={lc}")
+        return f"{name} from={self.sender_id} to={rec} lastchanged={lc}"
 
 
 def immediate_create_group(peers):

--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -12,6 +12,12 @@ def lsformat(members):
     l = map(lambda x: x if isinstance(x, str) else x.id, members)
     return ",".join(sorted(l, key=lambda x: int(x[1:])))
 
+def lcformat(lastchanged):
+    l = []
+    for peer_id in sorted(lastchanged):
+        l.append(f"{peer_id}->{lastchanged[peer_id]}")
+    return ", ".join(l)
+
 
 class Relay:
     def __init__(self, numpeers):
@@ -131,11 +137,7 @@ class Peer:
         return int(self.id[1:])
 
     def __repr__(self):
-        l = []
-        for peer_id in sorted(self.lastchanged):
-            l.append(f"{peer_id}->{self.lastchanged[peer_id]}")
-
-        lc = ", ".join(l)
+        lc = lcformat(self.lastchanged)
         return f"{self.id} members={lsformat(self.members)} lastchanged={{{lc}}}"
 
 
@@ -146,13 +148,11 @@ class IncomingMessage:
 
     def __repr__(self):
         rec = ",".join(sorted(self.recipients))
-        num_lastchanged = len(self.lastchanged)
+        lc = lcformat(self.lastchanged)
         name = self.typ
         if self.member:
             name += f"({self.member})"
-        return (
-            f"{name} from={self.sender_id} to={rec} num_lastchanged={num_lastchanged}"
-        )
+        return (f"{name} from={self.sender_id} to={rec} lastchanged={lc}")
 
 
 def immediate_create_group(peers):

--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -26,7 +26,7 @@ class Relay:
         self.peers = {}
         self.notify_retry_leave = []
         for i in range(numpeers):
-            newpeer = Peer(relay=self, num=i)
+            newpeer = Peer(relay=self, id=f"p{i}")
             self.peers[newpeer.id] = newpeer
 
     def get_peers(self):
@@ -139,9 +139,10 @@ class Relay:
 
 
 class Peer:
-    def __init__(self, relay, num):
+    def __init__(self, relay, id):
+        assert id.startswith("p"), id
         self.relay = relay
-        self.id = f"p{num}"
+        self.id = id
         self.members = set()
         self.from2mailbox = {}
         # dict which maps past/present members to timestamp

--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -94,7 +94,7 @@ class Relay:
         ok = True
         for peer1, peer2 in zip(peers, peers[1:]):
             if peer1.members == peer2.members:
-                nums = lsformat(peer.members)
+                nums = lsformat(peer1.members)
                 print(f"{peer1.id} and {peer2.id} have same members {nums}")
             else:
                 print(f"Peers member mismatch {peer1.id}.members != {peer2.id}.members")

--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -24,7 +24,7 @@ class Relay:
     def __init__(self, numpeers):
         self.count_receive_messages_calls = itertools.count()
         self.peers = {}
-        self.notify_stale = []
+        self.notify_retry_leave = []
         for i in range(numpeers):
             newpeer = Peer(relay=self, num=i)
             self.peers[newpeer.id] = newpeer
@@ -59,10 +59,10 @@ class Relay:
             if from_peer not in notfrom and peer not in notreceive:
                 self._drain_mailbox(peer, from_peer)
         self.dump(f"# [{count}] PROCESSED INCOMING MESSAGES, PEERSTATES:")
-        if self.notify_stale:
+        if self.notify_retry_leave:
             print("# notify peers who send us a message even though we left the group")
-            while self.notify_stale:
-                peer, stale_member = self.notify_stale.pop()
+            while self.notify_retry_leave:
+                peer, stale_member = self.notify_retry_leave.pop()
                 RetryLeave(peer, recipients=[stale_member])
         print(f"# [{count}] FINISH RECEIVING MESSAGES")
 
@@ -252,4 +252,4 @@ def update_peer_from_incoming_message(peer, msg):
                 stale_timestamps = True
 
     if stale_timestamps:
-        peer.relay.notify_stale.append((peer, msg.sender_id))
+        peer.relay.notify_retry_leave.append((peer, msg.sender_id))

--- a/gmc/gmc.py
+++ b/gmc/gmc.py
@@ -253,5 +253,5 @@ def update_peer_from_incoming_message(peer, msg):
                 # and we have a newer timestamp for ourselves
                 stale_timestamps = True
 
-    if stale_timestamps and msg.sender_id in peer.members:
+    if stale_timestamps:
         peer.relay.notify_stale.append((peer, msg.sender_id))

--- a/gmc/test_gmc.py
+++ b/gmc/test_gmc.py
@@ -205,6 +205,8 @@ def test_concurrent_removals():
 
     relay.receive_messages()
 
+    relay.assert_group_consistency(disjunct_ok=True)
+
     ChatMessage(p2)
     ChatMessage(p3)
     relay.receive_messages()
@@ -216,10 +218,4 @@ def test_concurrent_removals():
     assert len(p3.from2mailbox[p1]) == 1
     relay.receive_messages()
 
-    # below assert will fail with following peer states:
-    # p0 members=p2 lastchanged={p0->104, p1->102, p2->103}
-    # p1 members=p3 lastchanged={p0->104, p1->102, p3->105}
-    # p2 members=p2 lastchanged={p0->104, p1->102, p2->103}
-    # p3 members=p3 lastchanged={p0->104, p1->102, p3->105}
-
-    relay.assert_group_consistency()
+    relay.assert_group_consistency(disjunct_ok=True)

--- a/gmc/test_gmc.py
+++ b/gmc/test_gmc.py
@@ -95,7 +95,7 @@ def test_add_remove_and_stale_member_sends_chatmessage():
     ChatMessage(p3)
     relay.receive_messages()
 
-    relay.assert_group_consistency()
+    relay.assert_group_consistency(ignore_mailboxes=True)
 
     ChatMessage(p0)
     relay.receive_messages()
@@ -255,5 +255,8 @@ def test_multi_device_concurrent_delete():
     p0_2 = p0.add_device()
     DelMemberMessage(p0, member=p2.id)
     DelMemberMessage(p0_2, member=p3.id)
+    relay.receive_messages()
+    # one of p2/p3 will have filed a RetryLeave message
+    relay.assert_group_consistency(ignore_mailboxes=True)
     relay.receive_messages()
     relay.assert_group_consistency()

--- a/gmc/test_gmc.py
+++ b/gmc/test_gmc.py
@@ -171,6 +171,8 @@ def test_stale_member():
     # Now p2 has {p0, p1, p2} as members,
     # but p0 and p1 think p1 is not part of the group
     relay.receive_messages()
+    assert p2.from2mailbox
+    relay.receive_messages()
 
     # This check fails.
     relay.assert_group_consistency()

--- a/gmc/test_gmc.py
+++ b/gmc/test_gmc.py
@@ -238,6 +238,8 @@ def test_multi_device_concurrent_add():
 
     # both p2 and p3 have not received the other's AddMember
     # so we need one more chat message to update
+    # (Alternantively, we could make p0 detect concurrency
+    # and make them repeat the AddMemberMessage)
     ChatMessage(p0)
     relay.receive_messages()
 

--- a/gmc/test_gmc.py
+++ b/gmc/test_gmc.py
@@ -159,20 +159,17 @@ def test_removed_member_removes_another_while_offline():
 
 def test_stale_member():
     relay = Relay(numpeers=3)
-    p1, p2, p3 = relay.get_peers()
+    p0, p1, p2 = relay.get_peers()
 
-    immediate_create_group([p1])
+    immediate_create_group([p0, p1])
+    relay.dump("state after group created")
 
+    DelMemberMessage(p0, member=p1.id)
+    DelMemberMessage(p0, member=p0.id)
     AddMemberMessage(p1, member=p2.id)
-    relay.receive_messages()
 
-    DelMemberMessage(p1, member=p2.id)
-    DelMemberMessage(p1, member=p1.id)
-
-    AddMemberMessage(p2, member=p3.id)
-
-    # Now p3 has {p1, p2, p3} as members,
-    # but p1 and p2 think they succesfully left the group.
+    # Now p2 has {p0, p1, p2} as members,
+    # but p0 and p1 think p1 is not part of the group
     relay.receive_messages()
 
     # This check fails.

--- a/gmc/test_immediate_consistency.py
+++ b/gmc/test_immediate_consistency.py
@@ -48,7 +48,7 @@ def test_immediate_consistency(n_actors, n_contacts, steps):
                 DelMemberMessage(actor, member=random.choice(possible_contacts))
 
     relay.receive_messages()
-    relay.assert_group_consistency(peers=actors)
+    relay.assert_group_consistency(peers=actors, ignore_mailboxes=True)
     # let one actor send a message to synchronize all contacts
     ChatMessage(actors[0])
     relay.receive_messages()

--- a/gmc/test_immediate_consistency.py
+++ b/gmc/test_immediate_consistency.py
@@ -56,3 +56,57 @@ def test_immediate_consistency(n_actors, n_contacts, steps):
     relay.assert_group_consistency()
     relay.dump("something")
     print("algorithm achieved immediate consistency")
+
+
+@pytest.mark.parametrize("n_actors,steps", [(2, 20), (5, 50), (10, 500)])
+def test_immediate_consistency_concurrent_additions_removals(n_actors, steps):
+    # Actors who are going to add/remove contacts
+    # and send messages about this to each other.
+
+    relay = Relay(n_actors)
+    actors = list(relay.get_peers())
+    contact_ids = list(x.id for x in actors)
+
+    immediate_create_group(actors[:3])
+
+    for _t in range(steps):
+        # Select random actor.
+        group_members = [peer for peer in actors if peer.id in peer.members]
+        actor = random.choice(group_members)
+
+        for receive_from in group_members:
+            # Maybe receive a message or do nothing
+            relay._drain_mailbox(actor, receive_from, num=random.randrange(2))
+
+        if random.choice([True, False]):
+            continue
+
+        action = random.choice(["chat", "add", "remove"])
+        if action == "chat":
+            ChatMessage(actor)
+        elif action == "add":
+            possible_contacts = list(set(contact_ids).difference(actor.members))
+            if possible_contacts:
+                AddMemberMessage(actor, member=random.choice(possible_contacts))
+        elif action == "remove" and len(group_members) > 1:
+            possible_contacts = list(set(contact_ids).intersection(actor.members))
+            if possible_contacts:
+                DelMemberMessage(actor, member=random.choice(possible_contacts))
+
+    relay.receive_messages()
+
+    # let existing group-members send a message to synchronize all contacts
+    for peer in actors:
+        if peer.id in peer.members:
+            ChatMessage(peer)
+    relay.receive_messages()
+    # deliver any RetryLeave messages
+    relay.receive_messages()
+    relay.assert_group_consistency()
+
+    # check we also have no RetryLeave messages left
+    for peer in actors:
+        if peer.id in peer.members:
+            assert not peer.from2mailbox
+    relay.dump("something")
+    print("algorithm achieved immediate consistency")


### PR DESCRIPTION
This PR introduces an UpdateMessage which triggers exactly when a Peer is not a group-member and receives a message from a group member that contains a wrong timestamp. 

The UpdateMessage will only be sent to the "stale" peer who will update any timestamps he receives from the already-removed member. 

The automatic UpdateMessage sending mechanism could be abused to leak online-ness of a removed-members, however.  